### PR TITLE
msync: add a Throttle type to coalesce calls

### DIFF
--- a/throttle.go
+++ b/throttle.go
@@ -1,0 +1,128 @@
+package msync
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"sync"
+)
+
+// A Throttle coalesces calls to a function so that all concurrently active
+// goroutines share the result of a single execution of the function made by
+// one of the participating goroutines.
+//
+// A Throttle is initially idle. The first goroutine to access an idle throttle
+// by calling [Throttle.Call] begins a new session. All goroutines that call
+// the throttle during an active session block until either:
+//
+//   - The context governing the call ends, in which case it reports a zero
+//     value and the error that ended the context.
+//
+//   - The goroutine executing the throttled function completes its call and
+//     reports a value and error, which is shared among all the goroutines
+//     participating in the session.
+//
+// If the execution of the throttled function ends because the context
+// governing its calling goroutine ended, another waiting goroutine (if any) is
+// woken up and given an oppoartunity to call the throttled function.  Once all
+// concurrent goroutines have returned, the throttle is once again idle, and
+// the next caller will begin a new session.
+type Throttle[T any] struct {
+	run func(context.Context) (T, error)
+
+	μ      sync.Mutex
+	waits  []chan result[T]
+	active bool
+}
+
+type result[T any] struct {
+	value T
+	err   error
+}
+
+// NewThrottle constructs a new [Throttle] that executes run.
+func NewThrottle[T any](run func(context.Context) (T, error)) *Throttle[T] {
+	return &Throttle[T]{run: run}
+}
+
+// Call invokes the function guarded by t. Call is safe for concurrent use by
+// multiple goroutines.
+func (t *Throttle[T]) Call(ctx context.Context) (T, error) {
+	var zero T
+
+	t.μ.Lock()
+	for ctx.Err() == nil {
+		// Safety check: The lock must be held at this point.
+		if t.μ.TryLock() {
+			panic("lock is not held at start of call")
+		}
+
+		if t.active {
+			// Someone is already working on the call, wait for them.
+			ready := make(chan result[T], 1)
+			t.waits = append(t.waits, ready)
+			t.μ.Unlock()
+
+			select {
+			case <-ctx.Done():
+				// Our context has ended, give up on the call.
+				return zero, ctx.Err()
+			case r, ok := <-ready:
+				// The previous caller is finished.
+				t.μ.Lock()
+				if ok {
+					// The previous caller determined the result.
+					t.μ.Unlock()
+					return r.value, r.err
+				}
+
+				// The previous caller did not determine a result.
+				// We should go back and retry (if our ctx is still alive).
+				continue
+			}
+
+			// unreachable
+		}
+
+		// Begin a new session.
+		t.active = true
+
+		// Attempt to determine the result. This may fail if ctx ends, or may
+		// report some other error.
+		t.μ.Unlock()
+		v, err := func() (_ T, err error) {
+			defer func() {
+				if x := recover(); x != nil {
+					err = fmt.Errorf("panic in run: %v\n%s", x, string(debug.Stack()))
+				}
+			}()
+			return t.run(ctx)
+		}()
+		t.μ.Lock()
+		t.active = false
+
+		// If run succeeded, or our context has not yet completed, the result is
+		// determined.  Propagate it to any waiting tasks, and then return it.
+		if err == nil || ctx.Err() == nil {
+			for _, w := range t.waits {
+				w <- result[T]{value: v, err: err}
+				close(w)
+			}
+			t.waits = nil
+			t.μ.Unlock()
+			return v, err
+		}
+
+		// Otherwise, ctx ended before we could determine the result.  Signal any
+		// waiting tasks that they should try, and then fail back to the caller.
+		for _, w := range t.waits {
+			close(w) // N.B. no value sent signals a retry is needed
+		}
+		t.waits = nil
+		break
+	}
+
+	// Reaching here, our context has ended with no result determined.
+	t.μ.Unlock()
+	return zero, ctx.Err()
+}

--- a/throttle_test.go
+++ b/throttle_test.go
@@ -1,0 +1,122 @@
+package msync_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/creachadair/msync"
+	"github.com/fortytw2/leaktest"
+)
+
+func TestThrottle(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	t.Run("Basic", func(t *testing.T) {
+		th := msync.NewThrottle(func(context.Context) (int, error) {
+			return 12345, nil
+		})
+		for range 3 {
+			if v, err := th.Call(context.Background()); v != 12345 || err != nil {
+				t.Errorf("Call: got %v, %v; want 12345, nil", v, err)
+			}
+		}
+	})
+
+	t.Run("Slow", func(t *testing.T) {
+		th := msync.NewThrottle(func(ctx context.Context) (int, error) {
+			select {
+			case <-ctx.Done():
+				return 0, ctx.Err()
+			case <-time.After(50 * time.Millisecond):
+				return 12345, nil
+			}
+		})
+
+		t.Run("Fail", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+			defer cancel()
+
+			got, err := th.Call(ctx)
+			if got != 0 || !errors.Is(err, context.DeadlineExceeded) {
+				t.Errorf("Call: got %v, %v; want 0, %v", got, err, context.DeadlineExceeded)
+			}
+		})
+		t.Run("OK", func(t *testing.T) {
+			got, err := th.Call(context.Background())
+			if got != 12345 || err != nil {
+				t.Errorf("Call: got %v, %v; want 12345, nil", got, err)
+			}
+		})
+	})
+
+	t.Run("Many", func(t *testing.T) {
+		type idKey struct{}
+
+		var active atomic.Int32
+		th := msync.NewThrottle(func(ctx context.Context) (string, error) {
+			id := ctx.Value(idKey{}).(int)
+
+			v := active.Add(1)
+			defer active.Add(-1)
+			if v != 1 {
+				return "ouch", fmt.Errorf("%d active callers", v)
+			}
+			t.Logf("Caller %d is running the task", id)
+			time.Sleep(5 * time.Microsecond)
+			return "OK", nil
+		})
+
+		var next int
+		var wg sync.WaitGroup
+		for range 25 {
+			next++
+			id := next
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				ctx := context.WithValue(context.Background(), idKey{}, id)
+				v, err := th.Call(ctx)
+				if v != "OK" || err != nil {
+					t.Errorf("Call: got %q, %v, want OK, nil", v, err)
+				}
+			}()
+		}
+
+		wg.Wait()
+		if v := active.Load(); v != 0 {
+			t.Errorf("Have %d active after all complete", v)
+		}
+	})
+
+	t.Run("Panic", func(t *testing.T) {
+		ready := make(chan struct{})
+		th := msync.NewThrottle(func(context.Context) (bool, error) {
+			<-ready
+			panic("oh no")
+		})
+
+		var start, finish sync.WaitGroup
+		start.Add(3)
+		finish.Add(3)
+		for range 3 {
+			go func() {
+				defer finish.Done()
+				start.Done()
+				v, err := th.Call(context.Background())
+				if err == nil {
+					t.Errorf("Call: got %v, want error", v)
+				}
+			}()
+		}
+		start.Wait()
+		close(ready)
+		finish.Wait()
+	})
+}


### PR DESCRIPTION
A Throttle coalesces executions of a function, similar in function to a
single-flight (golang.org/x/sync/singleflight), but with a generic result type
and support for context cancellation and retries,
